### PR TITLE
Changelog update - `v1.0.8`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 
 All notable changes to the "Copy with inline issues" plugin will be documented in this file.
-
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.4/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
 
 ## [1.0.8]
 
 ### Fixed
+
 - **Deprecated API migration** - Replaced deprecated `ReadAction.compute(ThrowableComputable)` with `runReadAction` to resolve compatibility warning with IntelliJ Platform 261+
 - **Change notes not displayed** - Fixed build configuration that caused "What's New" section to always be empty in IDE plugin settings
 - **Cleaned up plugin description** - Removed emoji icons from plugin description, changelog, and README for a cleaner presentation
@@ -15,11 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.7] - 2025-12-15
 
 ### Changed
+
 - **Extended IDE compatibility** - Updated compatibility range to support IDE builds up to 272.* (through 2027.2)
 - **2025.3 Support** - Now compatible with WebStorm 2025.3, IntelliJ IDEA 2025.3, and all other JetBrains IDEs version 2025.3
 - **Improved plugin description** - Simplified and clarified the plugin description for better readability
 
 ### Technical
+
 - Updated `pluginUntilBuild` from 252.* to 272.* in gradle.properties
 - Streamlined README.md and plugin.xml descriptions for better user experience
 - Ensures compatibility with IDE versions 2024.2 through 2027.2
@@ -27,11 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.6] - 2025-01-19
 
 ### Fixed
+
 - **Deprecated API updates** - Replaced deprecated `AnActionEvent.getRequiredData()` calls with modern `getData()` API
 - **Enhanced null safety** - Added explicit null checks for improved error handling and compatibility
 - **Future-proofing** - Eliminated "scheduled for removal" API warnings in IntelliJ Platform 252+
 
 ### Technical
+
 - Updated `CopyWithInlineIssues.kt` to use `getData()` with null safety
 - Updated `CopyFileWithInlineIssues.kt` to use `getData()` with null safety
 - Maintained identical functionality while improving API compatibility
@@ -39,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.5] - 2025-01-18
 
 ### Changed
+
 - **Complete name consistency** - Updated all references from "Copy File with Problems" to "Copy with inline issues" across the entire project
 - **Fixed marketplace display** - Plugin now correctly shows as "Copy with inline issues" in JetBrains Marketplace
 - **Updated documentation** - All installation instructions and references use the new name consistently
@@ -47,12 +54,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.4] - 2025-01-18
 
 ### Changed
+
 - **Plugin name** updated from "Copy File with Problems" to "Copy with inline issues"
 - **Plugin description** updated to reflect new branding
 - **Version bumped** to 1.0.4 across all configuration files
 - **Documentation** updated to reflect new plugin name
 
 ### Technical
+
 - Added CLAUDE.md for development guidance and Claude Code integration
 - Updated GitHub Actions workflow with proper token usage
 - **Automatic deployment** - Added automated plugin publishing to JetBrains Marketplace
@@ -60,9 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2025-01-13
 
-### Initial Release
-
 ### Added
+
 - **Copy With Problems** action for selected text in the editor
 - **Copy File With Inline Issues** action for entire files in a project tree
 - Comprehensive error detection system with multiple detection methods:
@@ -89,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom icons for both actions
 
 ### Technical Features
+
 - Multiple error detection strategies for comprehensive coverage
 - Relative path calculation from the project root
 - Distinct severity levels (ERROR, WARNING, INFO)
@@ -96,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integration with IntelliJ's inspection profile system
 
 ### Use Cases
+
 - Code reviews with complete error context
 - Bug reporting with precise error information
 - Team collaboration without losing IDE context
@@ -103,8 +113,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stack Overflow posts with comprehensive context
 
 ### Requirements
+
 - IntelliJ IDEA 2024.2+ (Build 242+)
 - Compatible with all IntelliJ-based IDEs
 
-### Installation
-Install directly from the JetBrains Marketplace or download the plugin ZIP file.
+[Unreleased]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/compare/v1.0.8...HEAD
+[1.0.8]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/compare/v1.0.7...v1.0.8
+[1.0.7]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/compare/v1.0.6...v1.0.7
+[1.0.6]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/compare/v1.0.5...v1.0.6
+[1.0.5]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/compare/v1.0.0...v1.0.4
+[1.0.0]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/commits/v1.0.0


### PR DESCRIPTION
Current pull request contains patched `CHANGELOG.md` file for the `v1.0.8` version.