### PR TITLE
Changelog update - `v1.2.6`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.6] - 2026-08-16
+
 ### Fixed
 
 - **Large-selection confirmation dialog no longer runs inside a read action** — The prompt shown before copying a selection above 500 lines was wrapped in an explicit read action. A modal dialog pumps a nested event loop, and doing so while holding the read lock is a documented platform anti-pattern that can stall other IDE activity. The action already runs on the EDT with implicit read access and the dialog needs no read access at all, so the wrapper was removed. The prompt itself is unchanged.
@@ -222,7 +224,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - IntelliJ IDEA 2024.2+ (Build 242+)
 - Compatible with all IntelliJ-based IDEs
 
-[Unreleased]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/compare/v1.2.5...HEAD
+[Unreleased]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/compare/v1.2.6...HEAD
+[1.2.6]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/compare/v1.2.5...v1.2.6
 [1.2.5]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/compare/v1.2.4...v1.2.5
 [1.2.4]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/compare/v1.2.3...v1.2.4
 [1.2.3]: https://github.com/Israel-Kli/jetbrains-plugin-copy-with-inline-issues/compare/v1.2.2...v1.2.3


### PR DESCRIPTION
Current pull request contains patched `CHANGELOG.md` file for the `v1.2.6` version.